### PR TITLE
switch to png for screenshot

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -13,6 +13,6 @@
       "updater"
     ],
     "description": "Update flatpaks from the steam client.",
-    "image": "https://steamuserimages-a.akamaihd.net/ugc/1885347294331325509/8098EECB8DA11691B9151B1B7A815821F80D53B2/?imw=1200&imh=600"
+    "image": "https://i.imgur.com/9FfPN1a.png"
   }
 }


### PR DESCRIPTION
This change is to accomodate limitations of the plugin store